### PR TITLE
Refactored Cleverbot code into command

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -39,6 +39,8 @@ def command_prefix(bot, message):
         return "j!"
     if message.content.startswith("~"):
         return "~"
+    elif message.content.upper().startswith("JOHN"):
+        return ""
     else:
         return "j!"
 


### PR DESCRIPTION
Switched to a command rather than an on_message handler, plus refactored some code that was bad practice/would have unintentional side effects (e.g., `input = message.content.split(' ', 1)[1]` would not only override a default Python function but also only pass the first word of the input to the Cleverbot API