### PR TITLE
fix john saying stuff twice when no input

### DIFF
--- a/src/cogs/cleverbot.py
+++ b/src/cogs/cleverbot.py
@@ -29,6 +29,7 @@ class CleverbotCog(commands.Cog, name="Cleverbot"):
 
         if message is None:
             await ctx.send("Sorry, what was that?")
+            return
 
         if (
             isinstance(ctx.channel, discord.channel.TextChannel)


### PR DESCRIPTION
if you do "john", it will say "Sorry, what was that?" and then proceed to actually use the Cleverbot API key. I fix that!